### PR TITLE
Renamed some fields to represent what they are

### DIFF
--- a/pogo/Networking/Envelopes.proto
+++ b/pogo/Networking/Envelopes.proto
@@ -31,7 +31,7 @@ message Envelopes {
     double altitude = 9;
     AuthInfo auth_info = 10;
     AuthTicket auth_ticket = 11;
-    int64 unknown12 = 12;
+    int64 protocol_version = 12;
 
     message AuthInfo {
       string provider = 1;
@@ -39,7 +39,7 @@ message Envelopes {
 
       message JWT {
         string contents = 1;
-        int32 unknown2  = 2;
+        int32 contents_length  = 2;
       }
     }
   }


### PR DESCRIPTION
After some investigation (and prodding of the server) i've determined that 'Unknown12' in Envolopes.proto is the protocol version as setting it to anything but 989 results in a 'Bad protocol version' error message from the server.

I am assumign that within JWT the Unknown2 field is the string length of the contents field. People have been setting this to 59 and it's worked fine but setting to contents.Length also works fine. I guess for the moment it's not using the full access token.
