### PR TITLE
Allow protobuf export to idiomatic Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Run `python compile_single.py` to compile everything to a single file.
  - Add the `-o` or `--output` flag to set an output directory, the default is `out`.
  - Add the `-d` or `--desc_file` flag to only generate a descriptor file, `POGOProtos.desc` will be written to the specified output directory.
 
+##### Go
+ - Add the `--go_import_prefix` to prefix all imports in output go files for vendoring all dependencies
+ - Add the `--go_root_package` to specify the root package of the output files as it should be in your `$GOPATH` eg. `github.com/xxx/yyy/pogoprotos`
+
 ### Recursive compilation
 
 Recursive compilation loops through all directories and compiles every `.proto` file it finds to the specified output directory.

--- a/compile_single.py
+++ b/compile_single.py
@@ -15,6 +15,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-l", "--lang", help="Language to produce protoc files")
 parser.add_argument("-o", "--out_path", help="Output path for protoc files")
 parser.add_argument("-d", "--desc_file", action='store_true', help="For generating a .desc file only")
+parser.add_argument("--go_import_prefix", help="Prefix all imports in output go files for vendoring all dependencies")
+parser.add_argument("--go_root_package", help="The root package of the output files as it should be in your `$GOPATH` eg. `github.com/xxx/yyy/pogoprotos`")
 args = parser.parse_args()
 
 # Set defaults
@@ -22,6 +24,8 @@ lang = args.lang or "csharp"
 out_path = args.out_path or "out"
 desc_file = args.desc_file
 default_out_path = out_path == "out"
+go_import_prefix = args.go_import_prefix
+go_root_package = args.go_root_package
 
 # Determine where to store
 proto_path = os.path.abspath("src")
@@ -42,7 +46,10 @@ if not os.path.exists(out_path):
     os.makedirs(out_path)
 
 created_packages = []
+package_mappings = []
 
+# Go specific
+go_package_mappings = []
 
 def get_package(path):
     for file_name in os.listdir(path):
@@ -55,6 +62,14 @@ def get_package(path):
     return None
 
 
+def convert_to_go_package(pkg):
+    pkg = pkg.replace("POGOProtos.", "")
+    pkg = pkg.replace(".", "_").lower()
+    if pkg == "map":
+        pkg = "maps"
+
+    return "%s/%s" % (pkg, pkg)
+
 def walk_files(main_file, path, package, imports=None):
     if imports is None:
         imports = []
@@ -66,7 +81,17 @@ def walk_files(main_file, path, package, imports=None):
         exit()
 
     main_file.write('syntax = "proto3";\n')
+
+    short_package_name = str.split(package, '.')[-1].lower()
+
     main_file.write('package %s;\n\n' % package)
+
+    if lang == "go":
+        package = convert_to_go_package(package)
+        if short_package_name == "map":
+            short_package_name = "maps"
+        main_file.write('option go_package = "%s";\n' % short_package_name)
+
 
     messages = ""
 
@@ -90,6 +115,9 @@ def walk_files(main_file, path, package, imports=None):
                                 exit()
 
                             import_from_package = import_from_package_re.group(2).replace("/", ".")
+
+                            if lang == "go":
+                                import_from_package = convert_to_go_package(import_from_package)
 
                             if import_from_package not in imports:
                                 imports.append(import_from_package)
@@ -116,13 +144,64 @@ def walk_directory(path):
         if os.path.isdir(dir_name_path):
             package = get_package(dir_name_path)
             if package is not None:
-                package_file_path = os.path.join(tmp_path, package + ".proto")
+                if lang == "go":
+                    go_pkg = package.replace("POGOProtos.", "")
+                    go_pkg = go_pkg.replace(".", "_").lower()
+                    if go_pkg == "map":
+                        go_pkg = "maps"
+                    file_name = "%s/%s" % (go_pkg, go_pkg)
+                    package_mappings.append([go_pkg, (file_name + ".proto")])
+                else:
+                    file_name = package
+                    package_mappings.append([file_name, (file_name + ".proto")])
+
+                package_file_path = os.path.join(tmp_path, file_name + ".proto")
+
+                if lang == "go":
+                    package_directory = os.path.dirname(package_file_path)
+                    os.makedirs(package_directory)
 
                 with open(package_file_path, 'a') as package_file:
                     walk_files(package_file, dir_name_path, package)
                     created_packages.append(package)
 
             walk_directory(dir_name_path)
+
+def compile_directories(path):
+    for proto_file_name in os.listdir(path):
+        if lang == "go":
+            # Compile with the grpc plugin
+            command_out_path = "plugins=grpc"
+
+            # Allow to specify import_prefix for complete vendoring of dependencies
+            if go_import_prefix:
+                command_out_path += ",import_prefix=%s" % go_import_prefix
+
+            # Map the .proto files to go packages
+            if len(go_package_mappings) >= 1:
+                command_out_path += ",%s" % ",".join(go_package_mappings)
+
+            # Combine the output with all other output options
+            command_out_path = "%s:%s" % (command_out_path, os.path.abspath(out_path))
+        else:
+            command_out_path = os.path.abspath(out_path)
+
+        item_path = os.path.join(path, proto_file_name)
+
+        if os.path.isfile(item_path):
+
+            command = """{0} --proto_path="{1}" --{2}_out="{3}" "{4}\"""".format(
+                protoc_path,
+                tmp_path,
+                lang,
+                command_out_path,
+                item_path
+            )
+
+            call(command, shell=True)
+
+        elif os.path.isdir(item_path):
+            compile_directories(item_path)
 
 walk_directory(proto_path)
 
@@ -141,19 +220,15 @@ if desc_file:
 
     call(command, shell=True)
 else:
-    for proto_file_name in os.listdir(tmp_path):
-        proto_file_name_path = os.path.join(tmp_path, proto_file_name)
-        if os.path.isfile(proto_file_name_path):
-            command = """{0} --proto_path="{1}" --{2}_out="{3}" "{4}\"""".format(
-                protoc_path,
-                tmp_path,
-                lang,
-                out_path,
-                proto_file_name_path
-            )
+    if lang == "go":
+        if go_root_package:
+            mapper = (lambda m: """M{0}={1}""".format(m[1], os.path.join(go_root_package, m[0])))
+        else:
+            mapper = (lambda m: """M{0}={1}""".format(m[1], m[0]))
 
-            call(command, shell=True)
+        go_package_mappings = map(mapper, package_mappings)
+
+    compile_directories(tmp_path)
     compile_helper.finish_compile(out_path, lang)
-
 
 print("Done!")

--- a/compile_single.py
+++ b/compile_single.py
@@ -68,7 +68,7 @@ def convert_to_go_package(pkg):
     if pkg == "map":
         pkg = "maps"
 
-    return "%s/%s" % (pkg, pkg)
+    return pkg
 
 def walk_files(main_file, path, package, imports=None):
     if imports is None:
@@ -87,11 +87,9 @@ def walk_files(main_file, path, package, imports=None):
     main_file.write('package %s;\n\n' % package)
 
     if lang == "go":
-        package = convert_to_go_package(package)
-        if short_package_name == "map":
-            short_package_name = "maps"
-        main_file.write('option go_package = "%s";\n' % short_package_name)
-
+        go_pkg = convert_to_go_package(package)
+        package = "%s/%s" % (go_pkg, go_pkg)
+        main_file.write('option go_package = "%s";\n' % go_pkg)
 
     messages = ""
 
@@ -117,7 +115,8 @@ def walk_files(main_file, path, package, imports=None):
                             import_from_package = import_from_package_re.group(2).replace("/", ".")
 
                             if lang == "go":
-                                import_from_package = convert_to_go_package(import_from_package)
+                                go_pkg = convert_to_go_package(import_from_package)
+                                import_from_package = "%s/%s" % (go_pkg, go_pkg)
 
                             if import_from_package not in imports:
                                 imports.append(import_from_package)
@@ -145,10 +144,7 @@ def walk_directory(path):
             package = get_package(dir_name_path)
             if package is not None:
                 if lang == "go":
-                    go_pkg = package.replace("POGOProtos.", "")
-                    go_pkg = go_pkg.replace(".", "_").lower()
-                    if go_pkg == "map":
-                        go_pkg = "maps"
+                    go_pkg = convert_to_go_package(package)
                     file_name = "%s/%s" % (go_pkg, go_pkg)
                     package_mappings.append([go_pkg, (file_name + ".proto")])
                 else:


### PR DESCRIPTION
Thanks for making this library, it's a really good initiative and I would like to contribute by adding some support for exporting to Go.

Currently I only added support to the `compile_single.py` script as it is already reading the contents of the files and modifying the temporary intermediary. If we want to add support for the recursive compilation, we would also have to create temporary files that can be interpreted and modified before running through `protoc`.

I hope at least these few changes are alright!
