### PR TITLE
Fix UpgradePokemonMessage + Remove useless dependancy

### DIFF
--- a/src/POGOProtos/Data/Logs/FortSearchLogEntry.proto
+++ b/src/POGOProtos/Data/Logs/FortSearchLogEntry.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 package POGOProtos.Data.Logs;
 
 import "POGOProtos/Inventory/Item/ItemData.proto";
-import "POGOProtos/Enums/PokemonId.proto";
 
 message FortSearchLogEntry {
 	.POGOProtos.Data.Logs.FortSearchLogEntry.Result result = 1;

--- a/src/POGOProtos/Networking/Requests/Messages/UpgradePokemonMessage.proto
+++ b/src/POGOProtos/Networking/Requests/Messages/UpgradePokemonMessage.proto
@@ -2,5 +2,5 @@ syntax = "proto3";
 package POGOProtos.Networking.Requests.Messages;
 
 message UpgradePokemonMessage {
-	uint64 pokemon_id = 1;
+	fixed64 pokemon_id = 1;
 }


### PR DESCRIPTION
```
Fix UpgradePokemonMessage, use fixed64 instead of uint64 for pokemon_id
Remove useless dependancy (PokemonId in FortSearchLogEntry.proto)
```
