### PR TITLE
AssetDigestEntry.checksum should be a fixed32 rather than a uint32.

### DIFF
--- a/src/POGOProtos/Data/AssetDigestEntry.proto
+++ b/src/POGOProtos/Data/AssetDigestEntry.proto
@@ -5,7 +5,7 @@ message AssetDigestEntry {
 	string asset_id = 1;
 	string bundle_name = 2;
 	int64 version = 3;
-	uint32 checksum = 4;
+	fixed32 checksum = 4;
 	int32 size = 5;
 	bytes key = 6;
 }


### PR DESCRIPTION
This fixes an error when decoding AssetDigestEntry messages:

> Error: Illegal wire type for field Message.Field .POGOProtos.Data.AssetDigestEntry.checksum: 5 (0 expected)
