### PR TITLE
Add ability to test with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pushd /tmp
+  - wget https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip
+  - unzip protoc-3.0.0-beta-4-linux-x86_64.zip
+  - popd
+  - export PATH=/tmp/bin:$PATH
+script:
+  - ./compile.py
+  - rm -rf out
+  - ./compile.py -l python

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 POGOProtos
 ===================
 
+[![Build Status](https://travis-ci.org/AeonLucid/POGOProtos.svg?branch=master)](https://travis-ci.org/AeonLucid/POGOProtos)
+
 This repository contains the [ProtoBuf](https://github.com/google/protobuf) `.proto` files needed to decode the PokémonGo RPC.
 
 If you want to know which messages are implemented right now, click [here](https://github.com/AeonLucid/POGOProtos/blob/master/src/POGOProtos/Networking/Requests/RequestType.proto).

--- a/compile.py
+++ b/compile.py
@@ -42,6 +42,11 @@ else:
 if may_remove and os.path.exists(tmp_out_path):
     shutil.rmtree(tmp_out_path)
 
+# If any of the protoc builds fail, we continue on but exit with a non-0 exit
+# code so that any automation (such as CI testing) can be made aware of the
+# failure.
+exit_codes = []
+
 # Find protofiles and compile
 for root, dirnames, filenames in os.walk(proto_path):
     protos = fnmatch.filter(filenames, '*.proto')
@@ -74,8 +79,11 @@ for root, dirnames, filenames in os.walk(proto_path):
             os.path.abspath(proto_file)
         )
 
-        call(command, shell=True)
+        exit_codes.append(call(command, shell=True))
 
 compile_helper.finish_compile(out_path, lang)
 
 print("Done!")
+
+if any(c != 0 for c in exit_codes):
+  sys.exit(1)


### PR DESCRIPTION
Sorry - I submitted this too soon!

Anyway - this adds a `.travis.yml` file and slightly modifies `compile.py` to make it useful for CI-like things. The goal is to prevent things like the root cause of #86/#82.

If you decide to use this -- just merge this branch, head to Travis CI and toggle the repo on, and it should "just work," hopefully. I tested it out with on an intentionally broken commit (master without #86 applied) along with a working commit (master with #86 applied) and Travis failed and passed as expected.
