### PR TITLE
note haskell lib in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ If you don't want to compile POGOProtos but instead use it directly, check out t
 | .NET         | https://github.com/johnduhart/POGOProtos-dotnet       |
 | PHP          | https://github.com/jaspervdm/pogoprotos-php           |
 | Go           | https://github.com/pkmngo-odi/pogo-protos             |
+| Haskell      | https://github.com/relrod/pokemon-go-protobuf-types   |


### PR DESCRIPTION
I don't have a client lib making use of it yet, but I do have the `.proto` files compiling to Haskell with lenses, so might as well mention it in the readme.
