### PR TITLE
Unknown6 IAPs

### DIFF
--- a/src/POGOProtos/Inventory/Item.proto
+++ b/src/POGOProtos/Inventory/Item.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package POGOProtos.Inventory;
+
+message Item {
+	int32 item_id = 1;
+	int32 count = 2;
+	bool unseen = 3;
+}

--- a/src/POGOProtos/Inventory/Item.proto
+++ b/src/POGOProtos/Inventory/Item.proto
@@ -1,8 +1,0 @@
-syntax = "proto3";
-package POGOProtos.Inventory;
-
-message Item {
-	int32 item_id = 1;
-	int32 count = 2;
-	bool unseen = 3;
-}

--- a/src/POGOProtos/Networking/Envelopes/RequestEnvelope.proto
+++ b/src/POGOProtos/Networking/Envelopes/RequestEnvelope.proto
@@ -11,7 +11,7 @@ message RequestEnvelope {
 	uint64 request_id = 3;
 	repeated .POGOProtos.Networking.Requests.Request requests = 4;
 
-	.POGOProtos.Networking.Envelopes.Unknown6 unknown6 = 6;
+	repeated .POGOProtos.Networking.Envelopes.Unknown6 unknown6 = 6;
 	double latitude = 7;
 	double longitude = 8;
 	double altitude = 9;

--- a/src/POGOProtos/Networking/Envelopes/ResponseEnvelope.proto
+++ b/src/POGOProtos/Networking/Envelopes/ResponseEnvelope.proto
@@ -9,7 +9,7 @@ message ResponseEnvelope {
 	uint64 request_id = 2;
 	string api_url = 3;
 
-	.POGOProtos.Networking.Envelopes.Unknown6Response unknown6 = 6;
+	repeated .POGOProtos.Networking.Envelopes.Unknown6Response unknown6 = 6;
 	.POGOProtos.Networking.Envelopes.AuthTicket auth_ticket = 7;
 
 	repeated bytes returns = 100;

--- a/src/POGOProtos/Networking/Envelopes/Unknown6.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package POGOProtos.Networking.Envelopes;
 
 message Unknown6 {
-	int32 unknown1 = 1; //6
+	int32 request_type = 1; // 5 for IAPs, 6 is unknown still
 	Unknown2 unknown2 = 2;
 
 	message Unknown2 {

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -11,7 +11,7 @@ message Unknown6Response {
 	message Unknown2 {
 		uint64 unknown1 = 1;
 		repeated IAPItem items = 2;
-		repeated .POGOProtos.Data.Player.Currency player_currency = 3; // currencies that player has at the moment
+		repeated .POGOProtos.Data.Player.Currency player_currencies = 3; // currencies that player has at the moment
 		string unknown4 = 4; // Some base64 encoded stuff...
 		
 		message IAPItem {

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -10,13 +10,13 @@ message Unknown6Response {
 
 	message Unknown2 {
 		uint64 unknown1 = 1; // Maybe status? It's always 1 (success), so it's probably that.
-		repeated IAPItem items = 2; // Items to show in the shop
+		repeated StoreItem items = 2; // Items to show in the shop
 		repeated .POGOProtos.Data.Player.Currency player_currencies = 3; // currencies that player has at the moment
 		string unknown4 = 4; // Some base64 encoded stuff...
 		
-		message IAPItem {
-			int32 iap_id = 1; // Internal ID (probably for Google Play/App Store) example: "pgorelease.incenseordinary.1"
-			bool real_currency = 2; // If true, this item is bought with real currency (USD, etc.) instead of Pokecoins
+		message StoreItem {
+			string item_id = 1; // Internal ID (probably for Google Play/App Store) example: "pgorelease.incenseordinary.1"
+			bool is_iap = 2; // If true, this item is bought with real currency (USD, etc.) through the Play/App Store instead of Pokecoins
 			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs
 			.POGOProtos.Data.Player.Currency yields_currency = 4; // When bought, this IAP will yield this much currency
 			.POGOProtos.Inventory.Item yields_item = 5; // The item and count of such item that this IAP will yield

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -6,24 +6,24 @@ import "POGOProtos/Inventory/Item.proto";
 
 message Unknown6Response {
 	int32 response_type = 1; // Still don't know what 6 is, but 5 lists items available via IAPs. 
-	Unknown2 unknown2 = 2;
+	Unknown2 unknown2 = 2; // Response data
 
 	message Unknown2 {
-		uint64 unknown1 = 1;
-		repeated IAPItem items = 2;
+		uint64 unknown1 = 1; // Maybe status? It's always 1 (success), so it's probably that.
+		repeated IAPItem items = 2; // Items to show in the shop
 		repeated .POGOProtos.Data.Player.Currency player_currencies = 3; // currencies that player has at the moment
 		string unknown4 = 4; // Some base64 encoded stuff...
 		
 		message IAPItem {
-			int32 iap_id = 1;
+			int32 iap_id = 1; // Internal ID (probably for Google Play/App Store) example: "pgorelease.incenseordinary.1"
 			bool real_currency = 2; // If true, this item is bought with real currency (USD, etc.) instead of Pokecoins
 			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs
 			.POGOProtos.Data.Player.Currency yields_currency = 4; // When bought, this IAP will yield this much currency
 			.POGOProtos.Inventory.Item yields_item = 5; // The item and count of such item that this IAP will yield
 			repeated KeyValue tags = 6; // Stuff like SORT:12, CATEGORY:ITEMS
-			int32 unknown7 = 7;
+			int32 unknown7 = 7; // Possibly something to toggle visibility in the store/purchasibility?
 			
-			message KeyValue {
+			message KeyValue { // Don't know any better names to call this.
 				string key = 1;
 				string value = 2;
 			}

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -11,6 +11,8 @@ message Unknown6Response {
 	message Unknown2 {
 		uint64 unknown1 = 1;
 		repeated IAPItem items = 2;
+		repeated .POGOProtos.Data.Player.Currency player_currency = 3; // currencies that player has at the moment
+		string unknown4 = 4; // Some base64 encoded stuff...
 		
 		message IAPItem {
 			int32 iap_id = 1;

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -17,7 +17,7 @@ message Unknown6Response {
 		message StoreItem {
 			string item_id = 1; // Internal ID (probably for Google Play/App Store) example: "pgorelease.incenseordinary.1"
 			bool is_iap = 2; // If true, this item is bought with real currency (USD, etc.) through the Play/App Store instead of Pokecoins
-			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs
+			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs (with the exception of items that cost real money like Pokecoins, that's defined in the respective store)
 			.POGOProtos.Data.Player.Currency yields_currency = 4; // When bought, this IAP will yield this much currency
 			.POGOProtos.Inventory.Item yields_item = 5; // The item and count of such item that this IAP will yield
 			repeated KeyValue tags = 6; // Stuff like SORT:12, CATEGORY:ITEMS

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -20,10 +20,10 @@ message Unknown6Response {
 			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs (with the exception of items that cost real money like Pokecoins, that's defined in the respective store)
 			.POGOProtos.Data.Player.Currency yields_currency = 4; // When bought, this IAP will yield this much currency
 			.POGOProtos.Inventory.Item.ItemData yields_item = 5; // The item and count of such item that this IAP will yield
-			repeated KeyValue tags = 6; // Stuff like SORT:12, CATEGORY:ITEMS
+			repeated Tag tags = 6; // Stuff like SORT:12, CATEGORY:ITEMS
 			int32 unknown7 = 7; // Possibly something to toggle visibility in the store/purchasibility?
 			
-			message KeyValue { // Don't know any better names to call this.
+			message Tag {
 				string key = 1;
 				string value = 2;
 			}

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -19,7 +19,7 @@ message Unknown6Response {
 			bool is_iap = 2; // If true, this item is bought with real currency (USD, etc.) through the Play/App Store instead of Pokecoins
 			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs (with the exception of items that cost real money like Pokecoins, that's defined in the respective store)
 			.POGOProtos.Data.Player.Currency yields_currency = 4; // When bought, this IAP will yield this much currency
-			.POGOProtos.Inventory.Item yields_item = 5; // The item and count of such item that this IAP will yield
+			.POGOProtos.Inventory.Item.ItemData yields_item = 5; // The item and count of such item that this IAP will yield
 			repeated KeyValue tags = 6; // Stuff like SORT:12, CATEGORY:ITEMS
 			int32 unknown7 = 7; // Possibly something to toggle visibility in the store/purchasibility?
 			

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package POGOProtos.Networking.Envelopes;
 
 import "POGOProtos/Data/Player/Currency.proto";
-import "POGOProtos/Inventory/Item.proto";
+import "POGOProtos/Inventory/Item/ItemData.proto";
 
 message Unknown6Response {
 	int32 response_type = 1; // Still don't know what 6 is, but 5 lists items available via IAPs. 

--- a/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
+++ b/src/POGOProtos/Networking/Envelopes/Unknown6Response.proto
@@ -1,11 +1,30 @@
 syntax = "proto3";
 package POGOProtos.Networking.Envelopes;
 
+import "POGOProtos/Data/Player/Currency.proto";
+import "POGOProtos/Inventory/Item.proto";
+
 message Unknown6Response {
-	int32 unknown1 = 1; //6
+	int32 response_type = 1; // Still don't know what 6 is, but 5 lists items available via IAPs. 
 	Unknown2 unknown2 = 2;
 
 	message Unknown2 {
 		uint64 unknown1 = 1;
+		repeated IAPItem items = 2;
+		
+		message IAPItem {
+			int32 iap_id = 1;
+			bool real_currency = 2; // If true, this item is bought with real currency (USD, etc.) instead of Pokecoins
+			.POGOProtos.Data.Player.Currency currency_to_buy = 3; // This defines how much the item costs
+			.POGOProtos.Data.Player.Currency yields_currency = 4; // When bought, this IAP will yield this much currency
+			.POGOProtos.Inventory.Item yields_item = 5; // The item and count of such item that this IAP will yield
+			repeated KeyValue tags = 6; // Stuff like SORT:12, CATEGORY:ITEMS
+			int32 unknown7 = 7;
+			
+			message KeyValue {
+				string key = 1;
+				string value = 2;
+			}
+		}
 	}
 }


### PR DESCRIPTION
It seems `Unknown6` is much like the `Request` object. It seems like field 1 is the type of request, because when the server is sent 5, it returns everything that's in the shop (so, in-app purchases). I still have no idea what 7 is on the IAPs, it seems to always be 1 (or true). Maybe it's something like "is_active", so the client knows if it should show it or allow the user to buy it?

I've written some messages for IAPs, here are some examples of what the server sent the client:
### 1 Incense

```
2 {
  1: "pgorelease.incenseordinary.1" // item ID
  // field 2 is absent since this is buying an in game item with pokecoins
  3 { // currency to buy, in this case, 80 pokecoins
    1: "POKECOIN"
    2: 80
  }
  5 { // items that the player will get, in this case, 1 incense
    1: "ITEM_INCENSE_ORDINARY"
    2: 1
  }
  6 { // this is an item attribute with a key:value pattern
    1: "CATEGORY"
    2: "ITEMS"
  }
  6 {
    1: "SORT"
    2: "10" // we need to find out what this means!
  }
  7: 1 // probably success/status
}
```
### 100 Pokecoins

```
2 {
  1: "pgorelease.pokecoin.100"
  2: 1 // notice this, it's telling the client that this is buying currency with actual money
  // also notice the lack of field 3, the play store/app store tells the app how much it is based on the item ID
  4 {
    1: "POKECOIN"
    2: 100
  }
  6 {
    1: "CATEGORY"
    2: "POKECOINS"
  }
  6 {
    1: "SORT"
    2: "1"
  }
  7: 1
}
```
