### PR TITLE
Link to node-pogo-protos (pure JS implementation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ If you don't want to compile POGOProtos but instead use it directly, check out t
 
 *More will be added later when most proto files are added.*
 
-| Language     | Source                                                |
-|--------------|-------------------------------------------------------|
-| NodeJS       | https://github.com/rastapasta/node-pokemongo-protobuf |
-| .NET         | https://github.com/johnduhart/POGOProtos-dotnet       |
-| PHP          | https://github.com/jaspervdm/pogoprotos-php           |
-| Go           | https://github.com/pkmngo-odi/pogo-protos             |
-| Haskell      | https://github.com/relrod/pokemon-go-protobuf-types   |
+| Language         | Source                                                |
+|------------------|-------------------------------------------------------|
+| NodeJS           | https://github.com/rastapasta/node-pokemongo-protobuf |
+| NodeJS (pure JS) | https://github.com/cyraxx/node-pogo-protos            |
+| .NET             | https://github.com/johnduhart/POGOProtos-dotnet       |
+| PHP              | https://github.com/jaspervdm/pogoprotos-php           |
+| Go               | https://github.com/pkmngo-odi/pogo-protos             |
+| Haskell          | https://github.com/relrod/pokemon-go-protobuf-types   |


### PR DESCRIPTION
Why link to a second Node.JS module? Because the other one uses the C++ protobuf library which doesn't work well on some platforms. This one uses protobuf.js (with a custom fix for its proto3 bug), making it a pure JS implementation.
