### PR TITLE
Change DownloadURLEntry.Checksum's type to fixed32

### DIFF
--- a/src/POGOProtos/Data/DownloadUrlEntry.proto
+++ b/src/POGOProtos/Data/DownloadUrlEntry.proto
@@ -5,5 +5,5 @@ message DownloadUrlEntry {
 	string asset_id = 1;
 	string url = 2;
 	int32 size = 3;
-	uint32 checksum = 4;
+	fixed32 checksum = 4;
 }


### PR DESCRIPTION
Okay, finding this took an awful lot of time for me.

When we make a `GetDownloadUrls` request to the official servers, they respond with the following

```
100 {
  1 {
    1: "9649e04b-ccd8-4b1c-b066-cc75ed4c0976/1467338147687000"
    2: "https://storage.googleapis.com/cloud_assets_pgorelease/bundles/android/pm0101?generation=1467338147687000&GoogleAccessId=pgorelease-service-account@pgorelease.iam.gserviceaccount.com&Expires=1469970173&Signature=CY4YbWipMVMUzyDgHGceoo2NO429spFyH39p%2FSMltBlQOBYLcRD8panRgTH8tuMc3uB65rtp613IkGwUMaMMXx40v0NBECEsRXcggYxYluO2k4waShMyOmWHOomMPKwGXg5ot93wLH6aXFwv0%2FD%2FUaqZDrJYJ9bMRcsF2KlPPy363XbrbcSCcT19otqU3D9yjWU1mDbzRy9yZRqmaCu%2FPtWHKKWnUKiN2f2UqL8Gbulex8BDpm4OKf4lXnOwAKYDpcAMph%2FC3LKVhvoRuryzPRJgXojb1CvfHaY0svUFoKq0N%2FuFl9hzR8RAVLsAPaD%2FpKuql4BUm%2BZtoc%2BWi0lQXA%3D%3D"
    3: 169205
    4: 0xbe30d925
  }
}
```

Encoding the same thing ourselves (I'm making a custom server), we get

```
100 {
  1 {
    1: "fc7d2574-7176-4c18-ba33-9090a0df84d0/1467338274036000"
    2: "https://REDACTED.amazonaws.com/pm0150?X-Amz-Algorithm=xyz1%2Fs3%2Faws4_request&X-Amz-Date&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=ddddd"
    3: 474229
    4: 2612302599
  }
}
```

The app probably doesn't like this fixed32 -> uint32 change and complains saying that the CRC for the asset failed.

This thing made me re-rip all the assets twice, drop my db a couple of times, rip out all my hair and whatnot.
