### PR TITLE
Fix `deleted_item_key` in InventoryItem

### DIFF
--- a/src/POGOProtos/Inventory/InventoryItem.proto
+++ b/src/POGOProtos/Inventory/InventoryItem.proto
@@ -5,6 +5,10 @@ import "POGOProtos/Inventory/InventoryItemData.proto";
 
 message InventoryItem {
 	int64 modified_timestamp_ms = 1;
-	int64 deleted_item_key = 2;
+	DeletedItem deleted_item = 2;
 	.POGOProtos.Inventory.InventoryItemData inventory_item_data = 3;
+
+	message DeletedItem {
+		fixed64 pokemon_id = 1;
+	}
 }


### PR DESCRIPTION
This will fix GetInventoryItems while releasing pokemon. There may be
other things in this payload, but I haven't seen them yet.
