### PR TITLE
Improve consistency and make enumerators unique.

### DIFF
--- a/src/POGOProtos/Data/Battle/BattleType.proto
+++ b/src/POGOProtos/Data/Battle/BattleType.proto
@@ -3,6 +3,6 @@ package POGOProtos.Data.Battle;
 
 enum BattleType {
 	BATTLE_TYPE_UNSET = 0;
-	NORMAL = 1;
-	TRAINING = 2;
+	BATTLE_TYPE_NORMAL = 1;
+	BATTLE_TYPE_TRAINING = 2;
 }

--- a/src/POGOProtos/Enums/PokemonRarity.proto
+++ b/src/POGOProtos/Enums/PokemonRarity.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package POGOProtos.Enums;
 
 enum PokemonRarity {
-	NORMAL = 0;
-	LEGENDARY = 1;
-	MYTHIC = 2;
+	POKEMON_RARITY_NORMAL = 0;
+	POKEMON_RARITY_LEGENDARY = 1;
+	POKEMON_RARITY_MYTHIC = 2;
 }

--- a/src/POGOProtos/Networking/Responses/GetGymDetailsResponse.proto
+++ b/src/POGOProtos/Networking/Responses/GetGymDetailsResponse.proto
@@ -7,7 +7,7 @@ message GetGymDetailsResponse {
 	.POGOProtos.Data.Gym.GymState gym_state = 1;
 	string name = 2;
 	repeated string urls = 3;
-	POGOProtos.Networking.Responses.GetGymDetailsResponse.Result result = 4;
+	.POGOProtos.Networking.Responses.GetGymDetailsResponse.Result result = 4;
 	string description = 5;
 
 	enum Result {

--- a/src/POGOProtos/Networking/Responses/UseItemGymResponse.proto
+++ b/src/POGOProtos/Networking/Responses/UseItemGymResponse.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package POGOProtos.Networking.Responses;
 
 message UseItemGymResponse {
-	POGOProtos.Networking.Responses.UseItemGymResponse.Result result = 1;
+	.POGOProtos.Networking.Responses.UseItemGymResponse.Result result = 1;
 	int64 updated_gp = 2; // Gym Points (?)
 
 	enum Result {

--- a/src/POGOProtos/Settings/Master/Item/FoodAttributes.proto
+++ b/src/POGOProtos/Settings/Master/Item/FoodAttributes.proto
@@ -4,7 +4,7 @@ package POGOProtos.Settings.Master.Item;
 import "POGOProtos/Enums/ItemEffect.proto";
 
 message FoodAttributes {
-	repeated POGOProtos.Enums.ItemEffect item_effect = 1;
+	repeated .POGOProtos.Enums.ItemEffect item_effect = 1;
 	repeated float item_effect_percent = 2;
 	float growth_percent = 3;
 }


### PR DESCRIPTION
Uniqueness of enumerators allows us to generate a single .proto file from the
entire collection, making client code (especially C++ and Haskell code) much
simpler.

Consistency: all protos are usually referenced with an absolute path (starting
with "."), so I've changed the cases where it wasn't done like that.
