### PR TITLE
should be int64 just overflew for negative tths

### DIFF
--- a/src/POGOProtos/Map/Pokemon/WildPokemon.proto
+++ b/src/POGOProtos/Map/Pokemon/WildPokemon.proto
@@ -10,5 +10,5 @@ message WildPokemon {
 	double longitude = 4;
 	string spawn_point_id = 5;
 	.POGOProtos.Data.PokemonData pokemon_data = 7;
-	int32 time_till_hidden_ms = 11;
+	int64 time_till_hidden_ms = 11;
 }


### PR DESCRIPTION
negative tths are thought to be the time distance between niantic server start time and now, they just became smaller than -2,147,483,648 and thus there is an overflow now. -> 64 bit variable
