### PR TITLE
Hashes are unsigned. xxhash64 returns uint64.

### DIFF
--- a/src/POGOProtos/Networking/Envelopes/Signature.proto
+++ b/src/POGOProtos/Networking/Envelopes/Signature.proto
@@ -94,6 +94,6 @@ message Signature {
     bytes session_hash = 22; // 16 bytes, unique per session
     uint64 timestamp = 23; // epoch timestamp in ms
     repeated uint64 request_hash = 24; // hashes of each request message in a hashArray signed based on the auth_token or auth_info - xxhash64
-    int64 unknown25 = 25; // for 0.33 its static -8537042734809897855 or 0x898654dd2753a481, generated via xxHash64("\"b8fa9757195897aae92c53dbcf8a60fb3d86d745\"".ToByteArray(), 0x88533787)
+    uint64 unknown25 = 25; // for 0.33 its static 9909701338899653761 or 0x898654dd2753a481, generated via xxHash64("\"b8fa9757195897aae92c53dbcf8a60fb3d86d745\"".ToByteArray(), 0x88533787)
 
 }


### PR DESCRIPTION
int64 and uint64 are encoded the same way, with varint encoding: "If you use int32 or int64 as the type for a negative number, the resulting varint is always ten bytes long – it is, effectively, treated like a very large unsigned integer." (See https://developers.google.com/protocol-buffers/docs/encoding#signed-integers). In Java, this change has no effect. In languages that do support unsigned integers, this simplifies client code. Semantically, uint64 is more correct. On the wire, this change has no effect.
