### PR TITLE
PokemonData unknown33

### DIFF
--- a/src/POGOProtos/Data/PokemonData.proto
+++ b/src/POGOProtos/Data/PokemonData.proto
@@ -37,4 +37,5 @@ message PokemonData {
 	string nickname = 30;
 	int32 from_fort = 31;
 	int32 buddy_candy_awarded = 32;
+	float buddy_total_km_walked = 33;
 }

--- a/src/POGOProtos/Data/PokemonData.proto
+++ b/src/POGOProtos/Data/PokemonData.proto
@@ -37,4 +37,5 @@ message PokemonData {
 	string nickname = 30;
 	int32 from_fort = 31;
 	int32 buddy_candy_awarded = 32;
+	float unknown33 = 33;
 }


### PR DESCRIPTION
If you have a buddy-pokemon that has earned at least 1 candy this _field 33_ is part of the _PokemonData_-response.

This was found looking for a solution to [NicklasWallgren/PokemonGoAPI-PHP#142](https://github.com/NicklasWallgren/PokemonGoAPI-PHP/issues/142#issuecomment-251135683).

Using either of [bramp/protoc-gen-php](https://github.com/bramp/protoc-gen-php) or [google/protobuf](https://github.com/google/protobuf/tree/master/php) this surplus field causes an error while decoding.
