### PR TITLE
Correcting ReleasePokemonMessage

### DIFF
--- a/src/POGOProtos/Networking/Requests/Messages/ReleasePokemonMessage.proto
+++ b/src/POGOProtos/Networking/Requests/Messages/ReleasePokemonMessage.proto
@@ -3,4 +3,5 @@ package POGOProtos.Networking.Requests.Messages;
 
 message ReleasePokemonMessage {
 	fixed64 pokemon_id = 1;
+	repeated fixed64 pokemon_ids = 2;
 }


### PR DESCRIPTION
Since v0.29.0.proto this info it's already there, but this file was outdated with the big proto file.
This way is possible to mass transfer pokemons