### PR TITLE
Change altitude back to accuracy

### DIFF
--- a/src/POGOProtos/Networking/Envelopes/RequestEnvelope.proto
+++ b/src/POGOProtos/Networking/Envelopes/RequestEnvelope.proto
@@ -14,7 +14,7 @@ message RequestEnvelope {
 	repeated PlatformRequest platform_requests = 6;
 	double latitude = 7;
 	double longitude = 8;
-	double altitude = 9;
+	double accuracy = 9;
 
 	AuthInfo auth_info = 10;
 	.POGOProtos.Networking.Envelopes.AuthTicket auth_ticket = 11;


### PR DESCRIPTION
MITM dumps show that this field matches the accuracy in location fixes and differs from altitude.

A request envelope:
```json
{
	"status_code": 2,
	"request_id": redacted,
	"requests": [],
	"latitude": redacted,
	"longitude": redacted,
	"accuracy": 65,
	"ms_since_last_locationfix": "1664"
}
```
and a location fix from that request:
```json
{
	"name": "fused",
	"timestamp_ms": "103397",
	"altitude": 1503.15380859375,
	"latitude": redacted,
	"longitude": redacted,
	"device_speed": -1,
	"device_course": -1,
	"horizontal_accuracy": 65,
	"vertical_accuracy": 10,
	"provider_status": "RUNNING",
	"location_type": "NORMAL_PROVIDER"
}
```
