### PR TITLE
Add UnknownPtr8

### DIFF
--- a/src/POGOProtos/Networking/Platform/PlatformRequestType.proto
+++ b/src/POGOProtos/Networking/Platform/PlatformRequestType.proto
@@ -8,4 +8,5 @@ enum PlatformRequestType {
 	BUY_ITEM_IOS = 4;
 	GET_STORE_ITEMS = 5;
 	SEND_ENCRYPTED_SIGNATURE = 6;
+	UNKNOWN_PTR_8 = 8;
 }


### PR DESCRIPTION
Added UnknownPtr8 to the `PlatformRequestType`.  The naming of this was chosen to match the PogoDev Python API.